### PR TITLE
Bump READTHEDOCS Python to 3.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
+  version: 3.7
   install:
     - requirements: docs/rtd-requirements.txt
     - method: setuptools


### PR DESCRIPTION
 Numpy 1.19 is the last numpy with python 3.6 support. #53 
This causes issues with termplotlib when using readthedocs