### PR TITLE
Fix deprecated pandas DataFrame.append

### DIFF
--- a/stubs/model.py
+++ b/stubs/model.py
@@ -2166,14 +2166,14 @@ class Model:
                 tempdict[key] = getattr(self.parent_mesh, key)
 
             tempseries = pandas.Series(tempdict, name=self.parent_mesh.name)
-            df = df.append(tempseries, ignore_index=True)
+            df = pandas.concat([df, tempseries.to_frame().T], ignore_index=True)
             # child meshes
             for child_mesh in self.child_meshes.values():
                 tempdict = odict()
                 for key in properties_to_print:
                     tempdict[key] = getattr(child_mesh, key)
                 tempseries = pandas.Series(tempdict, name=child_mesh.name)
-                df = df.append(tempseries, ignore_index=True)
+                df = pandas.concat([df, tempseries.to_frame().T], ignore_index=True)
             # intersection meshes
             for child_mesh in self.parent_mesh.child_surface_meshes:
                 for mesh_id_pair in child_mesh.intersection_map.keys():
@@ -2209,7 +2209,7 @@ class Model:
                         mesh_id_pair
                     ].num_vertices()
                     tempseries = pandas.Series(tempdict, name=intersection_mesh_name)
-                    df = df.append(tempseries, ignore_index=True)
+                    df = pandas.concat([df, tempseries.to_frame().T], ignore_index=True)
 
             print(tabulate(df, headers="keys", tablefmt=tablefmt))
 

--- a/stubs/model_assembly.py
+++ b/stubs/model_assembly.py
@@ -222,15 +222,27 @@ class ObjectContainer:
             if properties_to_print and "idx" not in properties_to_print:
                 properties_to_print.insert(0, "idx")
             for idx, (name, instance) in enumerate(self.items):
-                df = df.append(
-                    instance.get_pandas_series(
-                        properties_to_print=properties_to_print, idx=idx
-                    )
+                df = pandas.concat(
+                    [
+                        df,
+                        instance.get_pandas_series(
+                            properties_to_print=properties_to_print, idx=idx
+                        )
+                        .to_frame()
+                        .T,
+                    ]
                 )
         else:
             for idx, (name, instance) in enumerate(self.items):
-                df = df.append(
-                    instance.get_pandas_series(properties_to_print=properties_to_print)
+                df = pandas.concat(
+                    [
+                        df,
+                        instance.get_pandas_series(
+                            properties_to_print=properties_to_print
+                        )
+                        .to_frame()
+                        .T,
+                    ]
                 )
         # # sometimes types are recast. change entries into their original types
         # for dtypeName, dtype in self.dtypes.items():


### PR DESCRIPTION
Pandas DataFrame `append` is deprecated, and we should use `pandas.concat` instead, see https://pandas.pydata.org/docs/dev/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append

It also currently break the CI: https://github.com/RangamaniLabUCSD/stubs/actions/runs/4751939310/jobs/8441675618