### PR TITLE
Replace fancy print function with logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
+        args: [--line-length=100]
+
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.

--- a/examples/example1/example1.py
+++ b/examples/example1/example1.py
@@ -16,6 +16,7 @@
 
 # +
 import os
+import logging
 
 import dolfin as d
 import sympy as sym
@@ -30,6 +31,8 @@ from stubs.model_assembly import (
 )
 
 # -
+
+logging.getLogger("stubs").setLevel(logging.INFO)
 
 # First, we define the various units for the inputs
 
@@ -98,9 +101,7 @@ def make_model():
 
     # Degradation of B in the cytosol
     k2f = Parameter("k2f", 10, 1 / sec)
-    r2 = Reaction(
-        "r2", ["B"], [], param_map={"on": "k2f"}, reaction_type="mass_action_forward"
-    )
+    r2 = Reaction("r2", ["B"], [], param_map={"on": "k2f"}, reaction_type="mass_action_forward")
 
     # Activating receptors on ERm with B
     k3f = Parameter("k3f", 100, 1 / (uM * sec))
@@ -168,9 +169,7 @@ model.initialize_discrete_variational_problem_and_solver()
 results = dict()
 os.makedirs("results", exist_ok=True)
 for species_name, species in model.sc.items:
-    results[species_name] = d.XDMFFile(
-        model.mpi_comm_world, f"results/{species_name}.xdmf"
-    )
+    results[species_name] = d.XDMFFile(model.mpi_comm_world, f"results/{species_name}.xdmf")
     results[species_name].parameters["flush_output"] = True
     results[species_name].write(model.sc[species_name].u["u"], model.t)
 

--- a/examples/misc/rabona/test_different_step_size_err.py
+++ b/examples/misc/rabona/test_different_step_size_err.py
@@ -35,17 +35,12 @@ for dt in [0.012, 0.01, 0.008, 0.006, 0.004, 0.002]:
         name="cyto",
     )
 
-    model = stubs.model_refactor.ModelRefactor(
-        pc, sc, cc, rc, config, solver_system, cyto_mesh
-    )
+    model = stubs.model_refactor.ModelRefactor(pc, sc, cc, rc, config, solver_system, cyto_mesh)
     model.initialize()
 
     # solve system
     model.solve()
     errors.append(
-        np.max(
-            model.u["cyto"]["u"].vector().get_local()
-            - (lambda t: 10 * np.exp(-5 * t))(model.t)
-        )
+        np.max(model.u["cyto"]["u"].vector().get_local() - (lambda t: 10 * np.exp(-5 * t))(model.t))
         / (lambda t: 10 * np.exp(-5 * t))(model.t)
     )

--- a/stubs/config.py
+++ b/stubs/config.py
@@ -151,6 +151,9 @@ def format_type_to_options(format_type: FormatType):
             new_lines=(0, 0),
             left_justify=True,
         )
+    else:
+        msg = f"Invalid format type {format_type}"
+        raise ValueError(msg)
 
 
 def format_message(title_text, format_type: FormatOption):

--- a/stubs/config.py
+++ b/stubs/config.py
@@ -2,9 +2,13 @@
 Configuration settings for simulation: plotting, reaction types, solution output, etc.
 """
 import logging
+from logging import config as logging_config
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from enum import Enum
+from typing import Any, Dict, Optional, Tuple, NamedTuple
 
+
+from termcolor import colored
 import dolfin as d
 import ufl
 
@@ -15,17 +19,217 @@ __all__ = [
     "SolverConfig",
     "BaseConfig",
     "FlagsConfig",
-    "LogLevelConfig",
 ]
 
-_loglevel_to_int: Dict[str, int] = {
-    "CRITICAL": int(d.LogLevel.CRITICAL),
-    "ERROR": int(d.LogLevel.ERROR),
-    "WARNING": int(d.LogLevel.WARNING),
-    "INFO": int(d.LogLevel.INFO),
-    "DEBUG": int(d.LogLevel.DEBUG),
-    "NOTSET": 0,
+
+comm = d.MPI.comm_world
+rank = comm.rank
+size = comm.size
+root = 0
+fancy_format = (
+    "%(asctime)s %(rank)s%(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+)
+base_format = "%(asctime)s %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+root_format = "ROOT -" + base_format
+
+
+class FormatType(str, Enum):
+    default = "default"
+    title = "title"  # type: ignore
+    subtitle = "subtitle"
+    data = "data"
+    data_important = "data_important"
+    log = "log"
+    logred = "logred"
+    log_important = "log_important"
+    log_urgent = "log_urgent"
+    warning = "warning"
+    timestep = "timestep"
+    solverstep = "solverstep"
+    assembly = "assembly"
+    assembly_sub = "assembly_sub"
+
+
+class FormatOption(NamedTuple):
+    buffer_color: str = "cyan"
+    text_color: str = "white"
+    filler_char: str = ""
+    num_banners: int = 0
+    new_lines: Tuple[int, int] = (0, 0)
+    left_justify: bool = False
+
+
+def format_type_to_options(format_type: FormatType):
+    if FormatType[format_type] == FormatType.default:
+        return FormatOption()
+    elif FormatType[format_type] == FormatType.title:
+        return FormatOption(
+            text_color="magenta",
+            num_banners=1,
+            new_lines=(1, 0),
+        )
+    elif FormatType[format_type] == FormatType.subtitle:
+        return FormatOption(
+            text_color="green",
+            filler_char=".",
+            left_justify=True,
+        )
+    elif FormatType[format_type] == FormatType.data:
+        return FormatOption(
+            buffer_color="white",
+            text_color="white",
+            filler_char="",
+            left_justify=True,
+        )
+    elif FormatType[format_type] == FormatType.data_important:
+        return FormatOption(
+            buffer_color="white",
+            text_color="red",
+            filler_char="",
+            left_justify=True,
+        )
+    elif FormatType[format_type] == FormatType.log:
+        return FormatOption(
+            buffer_color="white",
+            text_color="green",
+            filler_char="",
+            left_justify=True,
+        )
+    elif FormatType[format_type] == FormatType.logred:
+        return FormatOption(
+            buffer_color="white",
+            text_color="red",
+            filler_char="",
+            left_justify=True,
+        )
+    elif FormatType[format_type] == FormatType.log_important:
+        return FormatOption(
+            buffer_color="white",
+            text_color="magenta",
+            filler_char=".",
+        )
+    elif FormatType[format_type] == FormatType.log_urgent:
+        return FormatOption(
+            buffer_color="white",
+            text_color="red",
+            filler_char=".",
+        )
+    elif FormatType[format_type] == FormatType.warning:
+        return FormatOption(
+            buffer_color="magenta",
+            text_color="red",
+            filler_char="!",
+            num_banners=2,
+            new_lines=(1, 1),
+        )
+    elif FormatType[format_type] == FormatType.timestep:
+        return FormatOption(
+            text_color="red",
+            num_banners=2,
+            filler_char=".",
+            new_lines=(1, 1),
+        )
+    elif FormatType[format_type] == FormatType.solverstep:
+        return FormatOption(
+            text_color="red",
+            num_banners=1,
+            filler_char=".",
+            new_lines=(1, 1),
+        )
+    elif FormatType[format_type] == FormatType.assembly:
+        return FormatOption(
+            text_color="magenta",
+            num_banners=0,
+            filler_char=".",
+            new_lines=(1, 0),
+        )
+    elif FormatType[format_type] == FormatType.assembly_sub:
+        return FormatOption(
+            text_color="magenta",
+            num_banners=0,
+            filler_char="",
+            new_lines=(0, 0),
+            left_justify=True,
+        )
+
+
+def format_message(title_text, format_type: FormatOption):
+    min_buffer_size = 5
+    terminal_width = 120
+    buffer_size = max(
+        [min_buffer_size, int((terminal_width - 1 - len(title_text)) / 2 - 1)]
+    )  # terminal width == 80
+    title_str_len = (buffer_size + 1) * 2 + len(title_text)
+    parity = 1 if title_str_len == 78 else 0
+
+    # color/stylize buffer, text, and banner
+    def buffer(buffer_size):
+        return colored(format_type.filler_char * buffer_size, format_type.buffer_color)
+
+    if format_type.left_justify:
+        title_str = (
+            f"{colored(title_text, format_type.text_color)} {buffer(buffer_size*2+1+parity)}"
+        )
+    else:
+        title_str = (
+            f"{buffer(buffer_size)} {colored(title_text, format_type.text_color)} "
+            f"{buffer(buffer_size+parity)}"
+        )
+    banner = colored(format_type.filler_char * (title_str_len + parity), format_type.buffer_color)
+    return banner, title_str
+
+
+class FancyFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        record.rank = f"CPU {rank}: " if size > 1 else ""
+        format_type = format_type_to_options(getattr(record, "format_type", FormatType.default))
+
+        formatter = logging.Formatter(fancy_format)
+
+        out = formatter.format(record)
+        banner, formatted_out = format_message(out, format_type=format_type)
+
+        banners = f"\n{banner}" * format_type.num_banners + "\n"
+        prefix = "\n" * format_type.new_lines[0]
+        postfix = ""
+        if format_type.num_banners > 0:
+            prefix += banners
+            postfix += banners
+        postfix += "\n" * format_type.new_lines[1]
+        return prefix + formatted_out + postfix
+
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "root": {"format": root_format},
+        "base": {"format": base_format},
+        "default": {"()": FancyFormatter},
+    },
+    "handlers": {
+        "console": {"class": "logging.StreamHandler", "formatter": "default"},
+        "root_console": {"class": "logging.StreamHandler", "formatter": "root"},
+    },
+    "loggers": {
+        "stubs": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+            # Don't send it up my namespace for additional handling
+            "propagate": False,
+        },
+        "pint": {"level": "ERROR"},
+        "FFC": {"level": "WARNING"},
+        "UFL": {"level": "WARNING"},
+        "dolfin": {"level": "INFO"},
+        "dijitso": {"level": "INFO"},
+    },
+    "root": {"handlers": ["root_console"], "level": "INFO"},
 }
+
+
+logging_config.dictConfig(LOGGING_CONFIG)
+
 
 global_settings = {
     "main_dir": None,
@@ -97,9 +301,7 @@ class SolverConfig(BaseConfig):
 
     final_t: Optional[float] = None
     use_snes: bool = True
-    snes_preassemble_linear_system: bool = (
-        False  #: .. warning:: FIXME Currently untested
-    )
+    snes_preassemble_linear_system: bool = False  #: .. warning:: FIXME Currently untested
     initial_dt: Optional[float] = None
     adjust_dt: Optional[Tuple[float, float]] = None
     time_precision: int = 6
@@ -127,40 +329,6 @@ class FlagsConfig(BaseConfig):
 
 
 @dataclass
-class LogLevelConfig(BaseConfig):
-    """
-    Settings for logging
-
-    :param FFC: LogLevel for FFC
-    :param UFL: LogLevel for UFL
-    :param dijitso: LogLevel for dijitso
-    :param dolfin: LogLevel for dolfin
-
-    """
-
-    FFC: str = "DEBUG"
-    UFL: str = "DEBUG"
-    djitso: str = "DEBUG"
-    dolfin: str = "INFO"
-
-    def set_logger_levels(self):
-        """
-        For each of the loggers, set the appropriate log-level
-        """
-        # set for dolfin
-        d.set_log_level(_loglevel_to_int[self.dolfin])
-
-        # set for others
-        other_loggers = list(self.__annotations__)
-        print(other_loggers)
-        other_loggers.remove("dolfin")
-        for logger_name in other_loggers:
-            logging.getLogger(logger_name).setLevel(
-                _loglevel_to_int[self.__getattribute__(logger_name)]
-            )
-
-
-@dataclass
 class Config:
     """
     Configuration settings.
@@ -173,7 +341,6 @@ class Config:
 
     solver: SolverConfig = field(default_factory=SolverConfig)
     flags: FlagsConfig = field(default_factory=FlagsConfig)
-    loglevel: LogLevelConfig = field(default_factory=LogLevelConfig)
 
     @property
     def reaction_database(self) -> Dict[str, str]:
@@ -181,17 +348,3 @@ class Config:
         Return database of known reactions
         """
         return {"prescribed": "k", "prescribed_linear": "k*u"}
-
-    def set_logger_levels(self):
-        self.loglevel.set_logger_levels()
-
-    def set_all_logger_levels(self, log_level: int):
-        """
-        Set all loggers to a given loglevel
-        :param log_level: The loglevel: `(0,10,20,30,40,50)`
-        """
-        # Update LogLevel class
-        for logger_name in self.loglevel.__annotations__:
-            self.loglevel.__setattr__(logger_name, log_level)
-        # Set LogLevels to logger
-        self.set_logger_levels()

--- a/stubs/model.py
+++ b/stubs/model.py
@@ -1309,7 +1309,7 @@ class Model:
         for idx, Ji in enumerate(J):
             idx_i, idx_j = divmod(idx, len(u))
             if Ji is None or Ji.empty():
-                logger.warning(
+                logger.info(
                     f"J{idx_i}{idx_j} = dF[{self.cc.get_index(idx_i).name}])"
                     f"/du[{self.cc.get_index(idx_j).name}] is empty",
                     extra=dict(format_type="logred"),
@@ -1527,7 +1527,7 @@ class Model:
         )
         self.update_time_dependent_parameters()
         if self.config.solver["use_snes"]:
-            logger.debug("Solving using PETSc.SNES Solver", dict(format_type="log"))
+            logger.info("Solving using PETSc.SNES Solver", dict(format_type="log"))
             self.stopwatches["snes all"].start()
 
             # Solve
@@ -1627,7 +1627,8 @@ class Model:
             if not self.solver.converged:
                 if not self.config.solver["attempt_timestep_restart_on_divergence"]:
                     raise RuntimeError(
-                        f"Model {self.name}: SNES diverged and "
+                        f"Model {self.name}: SNES diverged (Reason = "
+                        f"{self.solver.getConvergedReason()}) and "
                         "attempt_timestep_restart_on_divergence is False. Exiting."
                     )
                 self.stopwatches["Total time step"].stop()

--- a/stubs/model.py
+++ b/stubs/model.py
@@ -134,9 +134,6 @@ class Model:
         # Functional forms
         self.forms = FormContainer()
 
-        # Set loggers to logging levels defined in config
-        # self.config.set_logger_levels()
-
         # MPI
         self.mpi_comm_world = d.MPI.comm_world
         self.mpi_rank = self.mpi_comm_world.rank
@@ -192,7 +189,6 @@ class Model:
         self.dT = d.Constant(self.dt)
         self.tvec = [self.t]
         self.dtvec = [self.dt]
-        # self.config.set_logger_levels()
 
         self._init_1()
         self._init_2()
@@ -1221,7 +1217,6 @@ class Model:
                     else:
                         Fs.append(d.Form(Fsub))
                 Flist.append(Fs)
-        # logger.warning("[problem] create list of residual forms OK", format_type='log')
 
         # Decompose J blocks into subforms based on domain of integration
         Jlist = list()
@@ -1294,7 +1289,7 @@ class Model:
                     else:
                         Fs.append(d.Form(Fsub))
                 Flist.append(Fs)
-        # fancy_print("[problem] create list of residual forms OK", format_type='log')
+
         return Flist
 
     def get_block_J(self, Fsum, u):

--- a/stubs/solvers.py
+++ b/stubs/solvers.py
@@ -251,9 +251,6 @@ class stubsSNESProblem:
                         )
                     Jpetsc.append(d.PETScMatrix(Jsum))
 
-        for j in Jpetsc:
-            logger.debug(type(j))
-
         if self.is_single_domain:
             # We can't use a nest matrix
             self.Jpetsc_nest = Jpetsc[0].mat()
@@ -277,7 +274,7 @@ class stubsSNESProblem:
             for k in range(len(self.Fforms[j])):
                 if self.Fforms[j][k].function_space(0) is None:
                     if self.print_assembly:
-                        logger.info(
+                        logger.warning(
                             f"{self.Fjk_name(j,k)}] has no function space",
                             extra=dict(format_type="log"),
                         )
@@ -294,7 +291,7 @@ class stubsSNESProblem:
 
             if Fsum is None:
                 if self.print_assembly:
-                    logger.info(
+                    logger.debug(
                         f"{self.Fjk_name(j)} is empty - initializing as empty PETSc "
                         f"Vector with local size {self.local_sizes[j]} "
                         f"and global size {self.global_sizes[j]}",
@@ -322,7 +319,7 @@ class stubsSNESProblem:
         Jmats are created using assemble_mixed(Jform) and are dolfin.PETScMatrix types
         """
         if self.print_assembly:
-            logger.info("Assembling block Jacobian", extra=dict(format_type="assembly"))
+            logger.debug("Assembling block Jacobian", extra=dict(format_type="assembly"))
         self.stopwatches["snes jacobian assemble"].start()
         dim = self.dim
 
@@ -398,7 +395,7 @@ class stubsSNESProblem:
     def assemble_Fnest(self, Fnest):
         dim = self.dim
         if self.print_assembly:
-            logger.info("Assembling block residual vector", extra=dict(format_type="assembly"))
+            logger.debug("Assembling block residual vector", extra=dict(format_type="assembly"))
         self.stopwatches["snes residual assemble"].start()
 
         if self.is_single_domain:
@@ -532,12 +529,12 @@ class stubsSNESProblem:
             f"mallocs={int(info['mallocs']): <4}\n"
         )
         if k is None:
-            logger.info(
+            logger.debug(
                 f"Assembled form {self.Jijk_name(i,j,k)}:\n{info_str}",
                 extra=dict(format_type="data"),
             )
         else:
-            logger.info(
+            logger.debug(
                 f"Assembled subform {self.Jijk_name(i,j,k)}:\n{info_str}",
                 extra=dict(format_type="data"),
             )

--- a/stubs/utils.py
+++ b/stubs/utils.py
@@ -48,6 +48,4 @@ def json_to_ObjectContainer(json_str, data_type=None):
     elif data_type in ["reactions", "reaction", "r", "rxn"]:
         return ReactionContainer(df)
     else:
-        raise Exception(
-            "I don't know what kind of ObjectContainer this .json file should be"
-        )
+        raise Exception("I don't know what kind of ObjectContainer this .json file should be")

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -29,16 +29,13 @@ def test_Species_initialization(A_kwargs):
 
     assert math.isclose(A.initial_condition, kwargs["initial_condition"])
     assert (
-        A.initial_condition_quantity
-        == kwargs["initial_condition"] * kwargs["concentration_units"]
+        A.initial_condition_quantity == kwargs["initial_condition"] * kwargs["concentration_units"]
     )
     assert A.concentration_units == stubs.common.pint_unit_to_quantity(
         kwargs["concentration_units"]
     )
     assert math.isclose(A.D, kwargs["D"])
-    assert A.diffusion_units == stubs.common.pint_unit_to_quantity(
-        kwargs["diffusion_units"]
-    )
+    assert A.diffusion_units == stubs.common.pint_unit_to_quantity(kwargs["diffusion_units"])
     assert A.D_quantity == kwargs["D"] * kwargs["diffusion_units"]
 
     assert A.compartment_name == kwargs["compartment_name"]

--- a/tests/test_stubs_model_init.py
+++ b/tests/test_stubs_model_init.py
@@ -138,17 +138,13 @@ def test_stubs_model_init(model):
         pidx = pm_mesh.map_cell_to_parent_entity[idx]
         b = parent_mesh.facets[pidx]
         assert (a == b).all()
-        assert (
-            pm_mesh.cell_coordinates[idx] == parent_mesh.facet_coordinates[pidx]
-        ).all()
+        assert (pm_mesh.cell_coordinates[idx] == parent_mesh.facet_coordinates[pidx]).all()
 
     cyto_mesh = model.child_meshes["cytosol"]
     for idx in test_indices:
         # test child facet -> parent entity mapping
         pidx = cyto_mesh.map_facet_to_parent_entity[idx]
-        assert all(
-            cyto_mesh.map_facet_to_parent_vertex[idx, :] == parent_mesh.facets[pidx, :]
-        )
+        assert all(cyto_mesh.map_facet_to_parent_vertex[idx, :] == parent_mesh.facets[pidx, :])
 
     # check volumes and surfaces
     assert math.isclose(parent_mesh.get_nvolume("dx"), 16.0)


### PR DESCRIPTION
Replacing the `fancy_print` function with proper logging. Also implementing the same formatting as the `fancy_print` function.

To e.g set the log level to INFO you could use 
```python
import logging

logging.getLogger("stubs").setLevel(logging.INFO)
```

Please take a look at the output in the CI (or run it locally) and see if this looks OK and that the logging level set on the different statements make sense. 

Address https://github.com/RangamaniLabUCSD/stubs/issues/81#issuecomment-1521233302