### PR TITLE
Split workflow for building docs into build and deploy step

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,7 +4,7 @@ name: Build docs
 on:
   pull_request:
     branches:
-      - "main"
+      - "development"
 
   # This workflow can be executed inside another workfow file
   workflow_call:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,25 +1,15 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Build docs
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
+  pull_request:
     branches:
-    - "**"
+      - "main"
 
+  # This workflow can be executed inside another workfow file
+  workflow_call:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
 
 jobs:
 
@@ -55,29 +45,9 @@ jobs:
       - name: Build docs
         run: jupyter book build .
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+      - name: Upload documentation as artifact
+        uses: actions/upload-artifact@v3
         with:
+          name: documentation
           path: ${{ env.PUBLISH_DIR }}
-
-  # Single deploy job since we're just deploying
-  deploy:
-    if: github.ref == 'refs/heads/development'
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+          if-no-files-found: error

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: Deploy to github pages
 
 on:
   push:
-    branches: [main]
+    branches: [development]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,53 @@
+name: Deploy to github pages
+
+on:
+  push:
+    branches: [main]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+
+  # Build documentation/website. Will be downloaded in first step
+  build-docs:
+    uses: ./.github/workflows/build_docs.yml
+
+  deploy:
+    needs: [build-docs]
+
+    # Allow one concurrent deployment
+    concurrency:
+        group: "pages"
+        cancel-in-progress: true
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docs artifact
+        # docs artifact is uploaded by build-docs job
+        uses: actions/download-artifact@v3
+        with:
+          name: documentation
+          path: "./public"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./public"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/run_examples_mpi.yml
+++ b/.github/workflows/run_examples_mpi.yml
@@ -1,4 +1,4 @@
-name: Run examples
+name: Run examples with MPI
 
 on:
   push:


### PR DESCRIPTION
Make sure that we try to build documentation on every push when we have an open PR to the main branch (i.e `development`). This mean also that the example are not run before there is an open PR to the main branch. 
Also if multiple workflows are running on on the main branch then the deploy step will only run on the workflow with the highest priority.

Also renamed the workflow for running examples to 'Running examples with MPI', since that is what it does. 