### PR TITLE
Add coverage to GitHub summary and upload html report to artifact

### DIFF
--- a/.github/workflows/test_fenics_smart.yml
+++ b/.github/workflows/test_fenics_smart.yml
@@ -28,3 +28,16 @@ jobs:
       - name: Run tests
         run: |
          python3 -m pytest
+
+      - name: Extract Coverage
+        run: |
+          python3 -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
+          python3 -m coverage json
+          export TOTAL=$(python3 -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "total=$TOTAL" >> $GITHUB_ENV
+
+      - name: Upload HTML report.
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report
+          path: htmlcov


### PR DESCRIPTION
Address https://github.com/RangamaniLabUCSD/smart/issues/127

In this PR I extract the coverage from the unit tests and output them to GitHub summary. I also upload the html report for the coverage as an artifact (see screenshot which is taken from https://github.com/RangamaniLabUCSD/smart/actions/runs/5468259696)

<img width="1227" alt="Screenshot 2023-07-05 at 21 41 19" src="https://github.com/RangamaniLabUCSD/smart/assets/2010323/c2b0ad65-acca-45be-9d88-730c837a408b">

We have a few unit tests in the repo, but these are only testing a small portion of the library. To make sure we properly test the library we also run all the examples as a part of the CI system which will test a larger portion of the repo. Most of these examples also contains assert statements that checks the resulting solution. These examples are run when building the documentation, and to my knowledge there is no easy way to extract the coverage from this build which is why we only show the coverage for the unit tests. 