### PR TITLE
Bump version of actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install pyvista dependencies"
         run: apt-get update && apt-get install -y libgl1-mesa-glx libxrender1 xvfb nodejs

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -43,7 +43,7 @@ jobs:
           path: "./public"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -6,7 +6,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/run_examples_mpi.yml
+++ b/.github/workflows/run_examples_mpi.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       # This action sets the current path to the root of your github repo
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install pyvista dependencies"
         run: apt-get update && apt-get install -y libgl1-mesa-glx libxrender1 xvfb nodejs

--- a/.github/workflows/test_fenics_smart.yml
+++ b/.github/workflows/test_fenics_smart.yml
@@ -20,7 +20,7 @@ jobs:
     container: ghcr.io/scientificcomputing/fenics-gmsh:2023-04-21
     steps:
       # This action sets the current path to the root of your github repo
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install code"
         run: python3 -m pip install .[test]


### PR DESCRIPTION
For some reason, the `run-examples` workflow started failing. I suspect it might have something to do with the `actions/checkout` step, and I see that they recently bumped the major version: https://github.com/actions/checkout/releases