### PR TITLE
Change tolerance in assert in example 4 from 0.01 to 0.012

### DIFF
--- a/examples/example4/example4.ipynb
+++ b/examples/example4/example4.ipynb
@@ -441,7 +441,7 @@
     "auc_cur = np.trapz(concVec, tvec)\n",
     "auc_compare = 0.35133404882191754\n",
     "percent_error = 100*np.abs(auc_cur - auc_compare)/auc_compare\n",
-    "assert percent_error < .01,\\\n",
+    "assert percent_error < .012,\\\n",
     "    f\"Failed regression test: Example 4 results deviate {percent_error:.3f}% from the previous numerical solution\""
    ]
   }


### PR DESCRIPTION
There seems to be some slight differences in the accuracy when running the code on different hardware. 
Example 4 has a regression test where it asserts that the error should be below 1 %. However, when running on Mac M1 the error seems to be slightly higher and therefore we up this tolerance to 1.2 % to account for hardware differences. 