### PR TITLE
Make compatible with python3.8

### DIFF
--- a/smart/mesh_tools.py
+++ b/smart/mesh_tools.py
@@ -1138,17 +1138,18 @@ def write_mesh(
     hdf5.write(mf_cell, f"/mf{cell_dim}")
     hdf5.write(mf_facet, f"/mf{facet_dim}")
     # For visualization of domains
+    stem = filename.stem
     (
         d.File(
             mesh.mpi_comm(),
-            str(filename.with_stem(filename.stem + f"_mf{cell_dim}").with_suffix(".pvd")),
+            (filename.parent / f"{stem}_mf{cell_dim}").with_suffix(".pvd").as_posix(),
         )
         << mf_cell
     )
     (
         d.File(
             mesh.mpi_comm(),
-            str(filename.with_stem(filename.stem + f"_mf{facet_dim}").with_suffix(".pvd")),
+            (filename.parent / f"{stem}_mf{facet_dim}").with_suffix(".pvd").as_posix(),
         )
         << mf_facet
     )

--- a/smart/mesh_tools.py
+++ b/smart/mesh_tools.py
@@ -1137,19 +1137,3 @@ def write_mesh(
     hdf5.write(mesh, "/mesh")
     hdf5.write(mf_cell, f"/mf{cell_dim}")
     hdf5.write(mf_facet, f"/mf{facet_dim}")
-    # For visualization of domains
-    stem = filename.stem
-    (
-        d.File(
-            mesh.mpi_comm(),
-            (filename.parent / f"{stem}_mf{cell_dim}").with_suffix(".pvd").as_posix(),
-        )
-        << mf_cell
-    )
-    (
-        d.File(
-            mesh.mpi_comm(),
-            (filename.parent / f"{stem}_mf{facet_dim}").with_suffix(".pvd").as_posix(),
-        )
-        << mf_facet
-    )


### PR DESCRIPTION
`pathlib.Path.with_stem` is a python3.9 feature (see https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.with_stem) and since we want to support python3.8 we need to remove this dependency. 