### PR TITLE
Set loglevel in UFL_LEGACY

### DIFF
--- a/smart/config.py
+++ b/smart/config.py
@@ -275,6 +275,7 @@ LOGGING_CONFIG = {
         "pint": {"level": "ERROR"},
         "FFC": {"level": "WARNING"},
         "UFL": {"level": "WARNING"},
+        "UFL_LEGACY": {"level": "WARNING"},
         "dolfin": {"level": "INFO"},
         "dijitso": {"level": "INFO"},
     },


### PR DESCRIPTION
Since `ufl` has changed named to `ufl_legacy` we also need to update the the logging config in order for to catch these logs. 