### PR TITLE
Remove dataclasses and termplotlib as dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,9 @@ dependencies = [
     "Pint",
     "scipy>=1.1.0",
     "sympy",
-    "dataclasses",
     "cached-property",
     "tabulate",
     "termcolor",
-    "termplotlib",
 ]
 
 


### PR DESCRIPTION
`dataclasses` are included in python3.7 and above and since we require python>3.7 we not need the `dataclasses` backport. Also `termplotlib` is not used any place in the code so we don't need it.