### PR TITLE
Add petsc logging for snes solve

### DIFF
--- a/smart/model.py
+++ b/smart/model.py
@@ -1661,7 +1661,8 @@ class Model:
             self.stopwatches["snes all"].start()
 
             # Solve
-            self.solver.solve(None, self._ubackend)
+            with PETSc.Log.Event("solve"):
+                self.solver.solve(None, self._ubackend)
 
             # Store/compute timings
             logger.info(


### PR DESCRIPTION
This is essentially to enable the use of the profiling tools from petsc.

If you start the program and add the following line to the beginning of the scrip
```python
import petsc4py.PETSc as PETSc

PETSc.Log.begin()
```
then you can save the output in a text file of python file using 
```python
PETSc.Options().setValue("-log_view", ":filename.txt")
```
(see https://petsc.org/release/manualpages/Profiling/PetscLogView/ for more info).
You can also add this as a decorator on other functions (see https://www.firedrakeproject.org/optimising.html for some examples)